### PR TITLE
Fixed inability to open a file already in use by another process

### DIFF
--- a/include/cybozu/mmap.hpp
+++ b/include/cybozu/mmap.hpp
@@ -73,7 +73,7 @@ public:
 		, hMap_(0)
 		, size_(0)
 	{
-		hFile_ = CreateFileA(fileName.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+		hFile_ = CreateFileA(fileName.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
 					OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 		subOpen(fileName);
 	}
@@ -83,7 +83,7 @@ public:
 		, hMap_(0)
 		, size_(0)
 	{
-		hFile_ = CreateFileW(fileName.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL,
+		hFile_ = CreateFileW(fileName.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
 					OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
 		subOpen(fileName);
 	}


### PR DESCRIPTION
Please refer to https://stackoverflow.com/a/11855880

Steps to reproduce (I'm facing a problem like this when using the msoc library):
1) Open the password-protected "XXX.docx" document in Word.
2) Try to read this document using the msoc library.

**Expected:**
The file should be recognized as password-protected without any issues.

**Actual:**
The following exception is thrown:
> mmap:CreateFile:C:\XXX.docx:The process cannot access the file because it is being used by another process.(32)